### PR TITLE
layout fix

### DIFF
--- a/coffee/templates/index.jinja2
+++ b/coffee/templates/index.jinja2
@@ -102,41 +102,44 @@
 
       <div class="row clients">
         <div class="col-sm-12"><h2>Clients</h2></div>
-        <div class="col-sm-3">
+        <div class="col-sm-6 col-md-3">
           <div class="well">
             <h3>abakaffe-cli</h3>
             <iframe src="http://ghbtns.com/github-btn.html?user=oyvindrobertsen&repo=abakaffe-cli&type=watch"
                 allowtransparency="true" frameborder="0" scrolling="0" width="62" height="20"></iframe>
             <iframe src="http://ghbtns.com/github-btn.html?user=oyvindrobertsen&repo=abakaffe-cli&type=fork"
                 allowtransparency="true" frameborder="0" scrolling="0" width="53" height="20"></iframe>
-              <code>pip install abakaffe-cli</code>
+              <div><code>pip install abakaffe-cli</code></div>
           </div>
         </div>
-        <div class="col-sm-3">
+        <div class="col-sm-6 col-md-3">
           <div class="well">
             <h3>abakaffe-android</h3>
             <iframe src="http://ghbtns.com/github-btn.html?user=ftlno&repo=abakaffe-android&type=watch"
                 allowtransparency="true" frameborder="0" scrolling="0" width="62" height="20"></iframe>
             <iframe src="http://ghbtns.com/github-btn.html?user=ftlno&repo=abakaffe-android&type=fork"
                 allowtransparency="true" frameborder="0" scrolling="0" width="53" height="20"></iframe>
+            <div>&nbsp;</div>
           </div>
         </div>
-        <div class="col-sm-3">
+        <div class="col-sm-6 col-md-3">
           <div class="well">
             <h3>AbakaffeNotifier</h3>
             <iframe src="http://ghbtns.com/github-btn.html?user=Essoen&repo=AbakaffeNotifier&type=watch"
                 allowtransparency="true" frameborder="0" scrolling="0" width="62" height="20"></iframe>
             <iframe src="http://ghbtns.com/github-btn.html?user=Essoen&repo=AbakaffeNotifier&type=fork"
                 allowtransparency="true" frameborder="0" scrolling="0" width="53" height="20"></iframe>
+            <div>&nbsp;</div>
           </div>
         </div>
-        <div class="col-sm-3">
+        <div class="col-sm-6 col-md-3">
           <div class="well">
             <h3>abaapp</h3>
             <iframe src="http://ghbtns.com/github-btn.html?user=cristeahub&repo=abaapp&type=watch"
                 allowtransparency="true" frameborder="0" scrolling="0" width="62" height="20"></iframe>
             <iframe src="http://ghbtns.com/github-btn.html?user=cristeahub&repo=abaapp&type=fork"
                 allowtransparency="true" frameborder="0" scrolling="0" width="53" height="20"></iframe>
+            <div>&nbsp;</div>
           </div>
         </div>
      </div>


### PR DESCRIPTION
The widest content of some boxes would spill outside the box on narrow (not-mobile) page widths. This fix will make each box twice as wide on those widths. Also added some "empty" divs that make sure the boxes are all the same height, so that the 4x1 row becomes a pretty 2x2 grid.
