### PR TITLE
Fix the graph bug on Retina-displays

### DIFF
--- a/coffee/static/coffee.js
+++ b/coffee/static/coffee.js
@@ -1,5 +1,6 @@
 moment.lang('nb');
 var updating = {'status': false, 'stats': false},
+  jsChart,
   transform = function(d) {
     var out = {
         labels: [],
@@ -57,9 +58,14 @@ var updating = {'status': false, 'stats': false},
             scaleStepWidth: stepWidth,
             scaleStartValue: 0,
             animation: false
-          },
-          chart = new Chart(ctx).Line(model, options);
-        c.css('width', '');
+          };
+        if (!jsChart) {
+          jsChart = new Chart(ctx);
+          jsChart.Line(model, options);
+        }
+        else {
+          jsChart.Line(model, options);
+        }
         updating.stats = false;
       });
     }


### PR DESCRIPTION
There's a bug in GraphJS which makes graphs double in size on Retina displays whenever they're changed. See #12   (or [#161](https://github.com/nnnick/Chart.js/issues/161) for the Chart.js issue).

This fix only creates the chart once, and then updates it by adding a new line instead of recreating the whole chart. 
